### PR TITLE
Fix complex filter support.

### DIFF
--- a/sgmock/filters.py
+++ b/sgmock/filters.py
@@ -29,20 +29,20 @@ def Or(filters):
 def _compile_filters(filters):
 
     if isinstance(filters, dict):
-        op = filters.get('logical_operator', 'and')
-        conditions = filters['conditions']
+        op = filters.get('filter_operator', 'all')
+        conditions = filters['filters']
     else:
-        op = 'and'
+        op = 'all'
         conditions = filters
 
-    op_cls = Or if op == 'or' else And
+    op_cls = Or if op == 'any' else And
     return op_cls([_compile_condition(f) for f in conditions])
 
 
 def _compile_condition(condition):
 
     if isinstance(condition, dict):
-        if 'logical_operator' in condition:
+        if 'filter_operator' in condition:
             return _compile_filters(condition)
 
         op_name = condition['relation']

--- a/sgmock/shotgun.py
+++ b/sgmock/shotgun.py
@@ -266,7 +266,7 @@ class Shotgun(object):
         :param list fields: Which fields to return.
         :param order: Ignored.
         :param filter_operator: Ignored.
-        :param limite: Ignored.
+        :param limit: Ignored.
         :param retired_only: Ignored.
         :param page: Ignored.
 

--- a/tests/test_complex_filter_find.py
+++ b/tests/test_complex_filter_find.py
@@ -1,0 +1,59 @@
+from common import *
+
+
+class TestComplexFilterFind(TestCase):
+
+    def test_thing(self):
+        sg = Shotgun()
+        nameA = '{}_ProjectA'.format(mini_uuid())
+        a = sg.create('Project', dict(name=nameA, sg_status='Bid'))
+        nameB = '{}_ProjectB'.format(mini_uuid())
+        b = sg.create('Project', dict(name=nameB, sg_status='Bid'))
+        nameC = '{}_ProjectC'.format(mini_uuid())
+        c = sg.create('Project', dict(name=nameC, sg_status='Production'))
+
+        # Using AND as filter_operator
+        query = [
+            {
+                'filter_operator': 'all',
+                'filters': [
+                    ['name', 'is', nameB],
+                    ['sg_status', 'is', 'Bid'],
+                ]
+            }
+        ]
+        results = sg.find('Project', query)
+        assert len(results) == 1
+        self.assertSameEntity(results[0], b)
+
+        # Using OR as filter_operator
+        query = [
+            {
+                'filter_operator': 'any',
+                'filters': [
+                    ['name', 'is', nameB],
+                    ['sg_status', 'is', 'Production'],
+                ]
+            }
+        ]
+        results = sg.find('Project', query)
+        # NOTE: sgmock's find ignores order and always seems to return in index order
+        self.assertSameEntity(results[0], a)
+        self.assertSameEntity(results[1], c)
+
+        # Combine an AND and OR query
+        query = [
+            ['sg_status', 'is', 'Bid'],
+            {
+                'filter_operator': 'any',
+                'filters': [
+                    ['name', 'is', nameA],
+                    ['name', 'is', nameB],
+                ]
+            }
+        ]
+        results = sg.find('Project', query)
+        assert len(results) == 2
+        # NOTE: sgmock's find ignores order and always seems to return in index order
+        self.assertSameEntity(results[0], a)
+        self.assertSameEntity(results[1], b)


### PR DESCRIPTION
This fixes the ability to use complex filters in sgmock.
sgmock was originally looking for the wrong keywords. A test was added.